### PR TITLE
refactor(v2): remove coroutines, add once handlers

### DIFF
--- a/packages/v2/stamp-fns.lua
+++ b/packages/v2/stamp-fns.lua
@@ -480,8 +480,8 @@ function Credit(BlockHeight, credits, balances)
 end
 
 --- Reward
-function Reward(BlockHeight, lastReward, balances, stamps, stampHistory, cycleAllocations)
-  HandlePreviousRewardCycle(BlockHeight, balances, cycleAllocations)
+function Reward(BlockHeight, lastReward, balances, stamps, stampHistory, cycleAllocations, handlePreviousRewardCycle, handleNextRewardCycle)
+  handlePreviousRewardCycle(BlockHeight, balances, cycleAllocations)
   if not utils.positive(TableLength(stamps)) then
     return 'No Stamps'
   end
@@ -495,8 +495,7 @@ function Reward(BlockHeight, lastReward, balances, stamps, stampHistory, cycleAl
     return 'Error: Not Time to reward'
   end
 
-
-  HandleNextRewardCycle(BlockHeight, stamps, stampHistory, reward, cycleAllocations)
+  handleNextRewardCycle(BlockHeight, stamps, stampHistory, reward, cycleAllocations)
   return "Rewarded."
 end
 

--- a/packages/v2/stamp-fns.lua
+++ b/packages/v2/stamp-fns.lua
@@ -480,30 +480,94 @@ function Credit(BlockHeight, credits, balances)
 end
 
 --- Reward
-function Reward(BlockHeight, lastReward, balances, stamps, stampHistory, allocateAtomicAssets)
+function Reward(BlockHeight, lastReward, balances, stamps, stampHistory, cycleAllocations)
+  HandlePreviousRewardCycle(BlockHeight, balances, cycleAllocations)
   if not utils.positive(TableLength(stamps)) then
     return 'No Stamps'
   end
 
   local reward = GetReward(BlockHeight, balances)
+
   if reward == 'Error: Not Enough Reward' then
     return 'Error: Not Enough Reward'
   end
-
   if lastReward + 720 > BlockHeight then
     return 'Error: Not Time to reward'
   end
 
-  local assetRewards = Mint(stamps, reward)
-  local atomicAllocations = allocateAtomicAssets(assetRewards, BlockHeight)
 
-  UpdateRewardBalances(atomicAllocations, balances)
-  ClearStampHistory(stamps, stampHistory)
-
-  lastReward = BlockHeight
+  HandleNextRewardCycle(BlockHeight, stamps, stampHistory, reward, cycleAllocations)
   return "Rewarded."
 end
 
+function HandlePreviousRewardCycle(BlockHeight, balances, cycleAllocations)
+  local blockHeightsToRemove = {}
+  for blockHeight, _ in pairs(cycleAllocations) do
+    if blockHeight < BlockHeight then
+      UpdateRewardBalances(cycleAllocations[blockHeight], balances)
+      table.insert(blockHeightsToRemove, blockHeight)
+    end
+  end
+  for _, blockHeight in ipairs(blockHeightsToRemove) do
+    cycleAllocations[blockHeight] = nil
+  end
+  -- remove old _once_ handlers
+  RemoveOldHandlers()
+end
+
+function RemoveOldHandlers()
+  local handlersToRemove = {}
+  for _, handler in ipairs(Handlers.list) do
+    if handler.name:match('_once_') then
+      table.insert(handlersToRemove, handler.name)
+    end
+  end
+  for _, handlerName in ipairs(handlersToRemove) do
+    Handlers.remove(handlerName)
+  end
+end
+
+function HandleNextRewardCycle(BlockHeight, stamps, stampHistory, reward, cycleAllocations)
+  local assetRewards = Mint(stamps, reward)
+  if not cycleAllocations[BlockHeight] then
+    cycleAllocations[BlockHeight] = {}
+  end
+  for asset, _ in pairs(assetRewards) do
+    cycleAllocations[BlockHeight][asset] = false
+  end
+  local atomicAssets = {}
+  for asset, assetReward in pairs(assetRewards) do
+    local isAtomicAsset, owner = IsAtomicAsset(asset)
+    if isAtomicAsset then
+      atomicAssets[asset] = owner
+    end
+    cycleAllocations[BlockHeight][asset] = { [owner] = assetReward }
+  end
+  for asset, owner in pairs(atomicAssets) do
+    Handlers.once({ From = asset }, function (message)
+      local data = message.Data
+      if not data or type(data) ~= 'string' then
+        cycleAllocations[BlockHeight][asset] = { [owner] = reward }
+        return
+      end
+      local status, decodedInfo = pcall(json.decode, data)
+      if not status then
+        cycleAllocations[BlockHeight][asset] = { [owner] = reward }
+        return
+      end
+      local assetBalances = decodedInfo['Balances']
+      if not assetBalances then
+        cycleAllocations[BlockHeight][asset] = { [owner] = reward }
+        return
+      end
+      cycleAllocations[BlockHeight][asset] = Allocate(assetBalances, reward)
+    end)
+  end
+  for asset, _ in pairs(atomicAssets) do
+    Send({ Target = asset, Action = 'Info'})
+  end
+  ClearStampHistory(stamps, stampHistory)
+end
 
 function GetReward(BlockHeight, balances)
   TOTAL_SUPPLY = 435000 * 1e12
@@ -578,21 +642,6 @@ function Mint(stamps, reward)
 
 end
 
-function AllocateAtomicAssets(assetRewards, blockHeight)
-  local atomicAllocations = {}
-  for asset, reward in pairs(assetRewards) do
-    local isAtomicAsset, owner = IsAtomicAsset(asset)
-    if isAtomicAsset then
-      local atomicBalances = GetAtomicBalances(asset, owner, blockHeight)
-      local assetAllocations = Allocate(atomicBalances, reward)
-      atomicAllocations[asset] = assetAllocations
-    else
-      atomicAllocations[asset] = { [owner] = reward }
-    end
-  end
-  return atomicAllocations
-end
-
 function IsAtomicAsset(asset)
   local assetHeaders = drive.getDataItem(asset)
   if type(assetHeaders) == "string" then
@@ -612,14 +661,18 @@ function IsAtomicAsset(asset)
 end
 
 function GetAtomicBalances(asset, owner, blockHeight)
-  Send({ Target = asset, Action = "Info"})
-
+  local onceNonce = Handlers.onceNonce
   local nextBlockHeight = blockHeight + 5
   if not HangingReceives[nextBlockHeight] then
     HangingReceives[nextBlockHeight] = {}
   end
-  HangingReceives[nextBlockHeight][Handlers.onceNonce] = owner
+  HangingReceives[nextBlockHeight][onceNonce] = owner
+  Send({ Target = asset, Action = "Info"})
   local infoResponse = Receive({ From = asset })
+  if HangingReceives[nextBlockHeight] then
+    HangingReceives[nextBlockHeight][onceNonce] = nil
+  end
+  local data = infoResponse.Data
   local decodedInfo = json.decode(infoResponse.Data)
   local assetBalances = decodedInfo['Balances']
   if assetBalances then

--- a/packages/v2/stamp-handlers.lua
+++ b/packages/v2/stamp-handlers.lua
@@ -174,7 +174,7 @@ Handlers.add(
   function (message)
     local BlockHeight = message["Block-Height"]
     HandleHangingReceives(BlockHeight, HangingReceives)
-    Reward(BlockHeight, LastReward, Balances, Stamps, StampHistory, CycleAllocations)
+    Reward(BlockHeight, LastReward, Balances, Stamps, StampHistory, CycleAllocations, HandlePreviousRewardCycle, HandleNextRewardCycle)
     Credit(BlockHeight, Credits, Balances)
     Bound(StampHistory, MAXIMUM_STAMPS)
     LastReward = BlockHeight

--- a/packages/v2/stamp-handlers.lua
+++ b/packages/v2/stamp-handlers.lua
@@ -174,9 +174,10 @@ Handlers.add(
   function (message)
     local BlockHeight = message["Block-Height"]
     HandleHangingReceives(BlockHeight, HangingReceives)
-    Reward(BlockHeight, LastReward, Balances, Stamps, StampHistory, AllocateAtomicAssets)
+    Reward(BlockHeight, LastReward, Balances, Stamps, StampHistory, CycleAllocations)
     Credit(BlockHeight, Credits, Balances)
     Bound(StampHistory, MAXIMUM_STAMPS)
+    LastReward = BlockHeight
   end
 )
 

--- a/packages/v2/stamp-tests.lua
+++ b/packages/v2/stamp-tests.lua
@@ -1192,25 +1192,6 @@ function InitRewardTests()
   local assetAddress = 'ASSETASSETASSETASSETASSETASSETASSETASSET001'
   local assetAddress2 = 'ASSETASSETASSETASSETASSETASSETASSETASSET002'
   local assetAddress3 = 'ASSETASSETASSETASSETASSETASSETASSETASSET003'
-  function allocateAtomicAssets(assetRewards)
-    local assetBalances = {
-      [assetAddress] = {
-        [fromAddress] = 1
-      },
-      [assetAddress2] = {
-        [fromAddress] = 1,
-        [fromAddress2] = 1
-      },
-      [assetAddress3] = {
-        [ProcessId] = 1
-      }
-    }
-    local results = {}
-    for asset, reward in pairs(assetRewards) do
-      results[asset] = Allocate(assetBalances[asset], reward)
-    end
-    return results
-  end
   local lastReward = 788400
   StampTests:add(
     "REWARD: No stamps",
@@ -1222,7 +1203,7 @@ function InitRewardTests()
       local BlockHeight = 788450
       local testStamps = {}
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, allocateAtomicAssets)
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
 
       assert(rewardResult == 'No Stamps', 'Should throw not enough reward error')
     end
@@ -1250,7 +1231,7 @@ function InitRewardTests()
         }
       }
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, allocateAtomicAssets)
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
 
       assert(rewardResult == 'Error: Not Enough Reward', 'Should throw not enough reward error')
     end
@@ -1280,7 +1261,7 @@ function InitRewardTests()
         }
       }
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, allocateAtomicAssets)
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
 
       assert(rewardResult == 'Error: Not Time to reward', 'Not time to reward yet')
     end
@@ -1310,7 +1291,7 @@ function InitRewardTests()
         }
       }
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, allocateAtomicAssets)
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
 
       -- Process balance starts with 2 * 1e12, loses 1 * 1e12
       assert(testBalances[ProcessId] == utils.subtract(2 * 1e12, 1 * 1e12), 'Process balance should decrease by one reward')
@@ -1347,7 +1328,7 @@ function InitRewardTests()
       }
 
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, allocateAtomicAssets)
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
 
       local reward = 499371288304695
       -- Two unique stampers: 1/2 reward for each
@@ -1359,6 +1340,7 @@ function InitRewardTests()
       -- Asset 2 is registered to fromAddress and fromAddress2 - split reward (83228548050783)
       -- Asset 3 is registered to no one - reward goes to ProcessId (83228548050782)
 
+      print(testBalances)
       -- From address balance starts with 1000, receives asset 1 reward, receives 1/2 of asset 2 reward
       assert(testBalances[fromAddress] == utils.toBalanceValue(1000 + 332914192203130 + (83228548050782 / 2)), 'From address balance should increase')
       -- From address 2 balance starts with 0, receives 1/2 of asset 2 reward

--- a/packages/v2/stamp-tests.lua
+++ b/packages/v2/stamp-tests.lua
@@ -1203,7 +1203,8 @@ function InitRewardTests()
       local BlockHeight = 788450
       local testStamps = {}
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
+      local testCycleAllocations = {}
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, testCycleAllocations, HandlePreviousRewardCycle, HandleNextRewardCycle)
 
       assert(rewardResult == 'No Stamps', 'Should throw not enough reward error')
     end
@@ -1231,7 +1232,8 @@ function InitRewardTests()
         }
       }
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
+      local testCycleAllocations = {}
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, testCycleAllocations, HandlePreviousRewardCycle, HandleNextRewardCycle)
 
       assert(rewardResult == 'Error: Not Enough Reward', 'Should throw not enough reward error')
     end
@@ -1261,7 +1263,8 @@ function InitRewardTests()
         }
       }
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
+      local testCycleAllocations = {}
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, testCycleAllocations, HandlePreviousRewardCycle, HandleNextRewardCycle)
 
       assert(rewardResult == 'Error: Not Time to reward', 'Not time to reward yet')
     end
@@ -1291,7 +1294,8 @@ function InitRewardTests()
         }
       }
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
+      local testCycleAllocations = {}
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, testCycleAllocations, HandlePreviousRewardCycle, HandleNextRewardCycle)
 
       -- Process balance starts with 2 * 1e12, loses 1 * 1e12
       assert(testBalances[ProcessId] == utils.subtract(2 * 1e12, 1 * 1e12), 'Process balance should decrease by one reward')
@@ -1302,6 +1306,9 @@ function InitRewardTests()
   StampTests:add(
     "REWARD: Successful reward",
     function()
+      local assetAddress = 'KdGNI7elW1A2TRKeebCswK5Z8F9shBP5vzEDlT-eS6Y' -- No balances, owner: atkI1E32mchuz_nl9kgcDntECH0BOuHJ1FBgCvlcH5E
+      -- assetAddress2 - no owner - give to process
+      -- assetAddress3 - no owner - give to process
       local testBalances = {
         [fromAddress] = "1000",
         [targetAddress] = "3000",
@@ -1328,32 +1335,57 @@ function InitRewardTests()
       }
 
       local testStampHistory = {}
-      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory)
-
+      local testCycleAllocations = {}
+      -- handler to handle asset 1 response (no op)
+      Handlers.once({ From = assetAddress }, function (message)
+          return
+      end)
+      local rewardResult = Reward(BlockHeight, lastReward, testBalances, testStamps, testStampHistory, testCycleAllocations, HandlePreviousRewardCycle, HandleNextRewardCycle)
       local reward = 499371288304695
       -- Two unique stampers: 1/2 reward for each
       -- Asset 1 (stamped: from1, from2) receives 4/6 of the reward (1/3 of from1s reward + 1/1 of from2s reward) - 332914192203130
       -- Asset 2 (stamped: from1) receives 1/6 of the reward (1/3 of from1s reward) plus one remainder - 83228548050783
       -- Asset 3 (stamped: from1) receives 1/6 of the reward (1/3 of from1s reward) - 83228548050782
-
-      -- Asset 1 is registered to fromAddress - receives whole reward (332914192203130)
-      -- Asset 2 is registered to fromAddress and fromAddress2 - split reward (83228548050783)
+      
+      -- Asset 1 is registered to atkI1E32mchuz_nl9kgcDntECH0BOuHJ1FBgCvlcH5E - receives whole reward (332914192203130)
+      -- Asset 2 is registered to no one - reward goes to ProcessId (83228548050783)
       -- Asset 3 is registered to no one - reward goes to ProcessId (83228548050782)
 
-      print(testBalances)
-      -- From address balance starts with 1000, receives asset 1 reward, receives 1/2 of asset 2 reward
-      assert(testBalances[fromAddress] == utils.toBalanceValue(1000 + 332914192203130 + (83228548050782 / 2)), 'From address balance should increase')
-      -- From address 2 balance starts with 0, receives 1/2 of asset 2 reward
-      assert(testBalances[fromAddress2] == utils.toBalanceValue(0 + (83228548050782 / 2)), 'From address 2 balance should increase')
-
-      -- Process balance starts with 2 * e12, receives asset 3 reward, plus one remainder
-      assert(testBalances[ProcessId] == utils.toBalanceValue((2 * 1e12) + 83228548050782 + 1), 'Process balance should increase')
-
-      -- Target balance unchanged
-      assert(testBalances[targetAddress] == utils.toBalanceValue(3000), 'Target address balance should be unchanged')
-
+      -- Cycle allocations for block height should be: BlockHeight: Asset: Owner / Process: Balance
+      assert(testCycleAllocations[BlockHeight][assetAddress]['atkI1E32mchuz_nl9kgcDntECH0BOuHJ1FBgCvlcH5E'] == 332914192203130, 'Cycle allocation for asset 1 should be to owner')
+      assert(testCycleAllocations[BlockHeight][assetAddress2][ProcessId] == 83228548050782, 'Cycle allocation for asset 2 should be to process')
+      assert(testCycleAllocations[BlockHeight][assetAddress3][ProcessId] == 83228548050783, 'Cycle allocation for asset 3 should be to process')
+      
+      -- Balances should not change on the first reward cycle
+      assert(testBalances[fromAddress] == utils.toBalanceValue(1000), 'From address balance should not change')
+      assert(testBalances[targetAddress] == utils.toBalanceValue(3000), 'Target address balance should not change')
+      assert(testBalances[ProcessId] == utils.toBalanceValue(2 * 1e12), 'Process balance should not change')
+      
       assert(TableLength(testStamps) == 0, 'Stamps should be emptied')
       assert(rewardResult == 'Rewarded.', 'Should be successful reward')
+      
+
+      -- Run next reward cycle
+      IncreasedBlockHeight = BlockHeight + 1000
+      local secondResult = Reward(IncreasedBlockHeight, lastReward, testBalances, testStamps, testStampHistory, testCycleAllocations)
+      assert(TableLength(testCycleAllocations) == 0, 'Cycle allocations should have no entries')
+      assert(testBalances[fromAddress] == utils.toBalanceValue(1000), 'From address balance should not change')
+      assert(testBalances[targetAddress] == utils.toBalanceValue(3000), 'Target address balance should not change')
+      assert(testBalances['atkI1E32mchuz_nl9kgcDntECH0BOuHJ1FBgCvlcH5E'] == utils.toBalanceValue(332914192203130), 'Asset 1 owner should receive reward')
+      assert(testBalances[ProcessId] == utils.toBalanceValue(83228548050782 + 83228548050783 + (2 * 1e12)), 'Process should receive reward')
+      assert(TableLength(testStamps) == 0, 'Stamps should be emptied')
+      assert(secondResult == 'No Stamps', 'No new stamps on second run')
+      -- From address balance starts with 1000, receives asset 1 reward, receives 1/2 of asset 2 reward
+      -- assert(testBalances[fromAddress] == utils.toBalanceValue(1000 + 332914192203130 + (83228548050782 / 2)), 'From address balance should increase')
+      -- -- From address 2 balance starts with 0, receives 1/2 of asset 2 reward
+      -- assert(testBalances[fromAddress2] == utils.toBalanceValue(0 + (83228548050782 / 2)), 'From address 2 balance should increase')
+
+      -- -- Process balance starts with 2 * e12, receives asset 3 reward, plus one remainder
+      -- assert(testBalances[ProcessId] == utils.toBalanceValue((2 * 1e12) + 83228548050782 + 1), 'Process balance should increase')
+
+      -- -- Target balance unchanged
+      -- assert(testBalances[targetAddress] == utils.toBalanceValue(3000), 'Target address balance should be unchanged')
+
     end
   )
 end

--- a/packages/v2/stamps-v2.lua
+++ b/packages/v2/stamps-v2.lua
@@ -43,7 +43,7 @@ Claimables = Claimables or {}
 Credits = Credits or {}
 
 Stamps = Stamps or {}
-
+CycleAllocations = CycleAllocations or {}
 HangingReceives = HangingReceives or {}
 
 -- GQL Indexes


### PR DESCRIPTION
Refactors the Reward function to remove coroutines (`Receive`) and instead build own Handlers.once function to add response balances to a global table (`CycleAllocations`). This removes the need to await each individual `Info` call, especially when the processes do not respond / do not have balances